### PR TITLE
Fix default timer init to start at 1 minute

### DIFF
--- a/views/countdown_view.h
+++ b/views/countdown_view.h
@@ -11,7 +11,7 @@
 #define SCREEN_CENTER_X (SCREEN_WIDTH / 2)
 #define SCREEN_CENTER_Y (SCREEN_HEIGHT / 2)
 
-#define INIT_COUNT 10
+#define INIT_COUNT 60
 
 typedef enum {
     CountDownTimerMinuteUp,


### PR DESCRIPTION
This changes the default timer to be start at exactly 1 minute which I would say provide more practical and intuitive use for user